### PR TITLE
[notag] chore: update actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: checks
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: make venv
         run: make venv


### PR DESCRIPTION
Updating deprecated actions/checkout@v4 to v6.