### PR TITLE
Ignore 'release candidate' tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ working/
 TODO.md
 *.bak
 .claude/
+PROMPT.log

--- a/INIT_SESSION.md
+++ b/INIT_SESSION.md
@@ -1,0 +1,40 @@
+# INIT_SESSION.md
+
+Audience: AI agents starting a new session in this repo.
+
+## What this project is
+
+`pyproject-version-action` is a **GitHub composite Action** that validates the
+`version` in `pyproject.toml` against the next expected SemVer tag for a PR.
+It is consumed by other repos via their workflows; this repo is the source of
+the Action.
+
+- `action.yaml` — composite Action definition. Sets up Python 3.13, installs
+  `requirements.txt`, then runs `action.py`.
+- `action.py` — main script. Reads `pyproject.toml` version, runs `git describe`
+  to find the latest `vX.Y.Z` tag, reads the PR title to determine which
+  semver component to bump (`[major]` / `[minor]` / `[patch]` / `[notag]`),
+  then asserts the bumped version equals the one written in `pyproject.toml`.
+- `tests/test_action.py` — pytest unit tests, all functions mocked (no real
+  git / GitHub calls).
+
+## Key behaviors to know
+
+- On `master` branch the script exits early (no validation).
+- PR title must contain one of `[major]`, `[minor]`, `[patch]`, `[notag]` —
+  otherwise the script dies.
+- `git describe` is called with `--match=v*.*.*`, `--exclude=*/*`, and
+  `--exclude=*-rc[0-9]*` so that namespaced tags (e.g. `foo/v1.2.3`) and
+  release-candidate tags (e.g. `v1.2.3-rc1`) are ignored.
+- The `v` prefix is stripped from the discovered tag before comparison.
+
+## Tooling / conventions
+
+- Python 3.13, managed via a project `.venv` (`make venv` creates it).
+- `make check` runs `ruff format --check`, `ruff check`, and `mypy`.
+- `make test` runs `pytest` with `coverage`.
+- `make fmt` reformats with `ruff` and applies lint fixes.
+
+Every change to `action.py` should come with a corresponding test in
+`tests/test_action.py`, and `make check` + `make test` should pass before
+considering the work done.

--- a/action.py
+++ b/action.py
@@ -114,7 +114,11 @@ def git_describe_version():
     # Read tag using git describe
     repo = Repo()
     git_tag = repo.git.describe(
-        "--abbrev=0", "--tags", "--match=v*.*.*", "--exclude=*/*"
+        "--abbrev=0",
+        "--tags",
+        "--match=v*.*.*",
+        "--exclude=*/*",
+        "--exclude=*-rc[0-9]*",
     )
 
     # String 'v' character

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -109,8 +109,22 @@ class TestGitDescribeVersion:
         result = action.git_describe_version()
         assert result == "1.2.3"
         mock_git.describe.assert_called_once_with(
-            "--abbrev=0", "--tags", "--match=v*.*.*", "--exclude=*/*"
+            "--abbrev=0",
+            "--tags",
+            "--match=v*.*.*",
+            "--exclude=*/*",
+            "--exclude=*-rc[0-9]*",
         )
+
+    @patch("action.Repo")
+    def test_git_describe_excludes_rc_tags(self, mock_repo):
+        mock_git = MagicMock()
+        mock_git.describe.return_value = "v1.2.3"
+        mock_repo.return_value.git = mock_git
+
+        action.git_describe_version()
+        args = mock_git.describe.call_args.args
+        assert "--exclude=*-rc[0-9]*" in args
 
 
 class TestReadPrTitle:


### PR DESCRIPTION
When evaluating which tag is the most recent, ignore tags that end in `rcX`, eg `v1.9.1-rc2`, as these tags are "release candidates" not actual releases.